### PR TITLE
deps: drop no longer needed runtime dependency on setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,6 @@ setup(
     license='ZPL-2.1',
     python_requires='>=3.9',
     install_requires=[
-        'setuptools',
         'zope.browser',
         'zope.component>=3.7',
         'zope.configuration',


### PR DESCRIPTION
`setuptools` is not used anywhere in this project for runtime and can be dropped.

Fixes: https://github.com/zopefoundation/zope.browsermenu/issues/21